### PR TITLE
Fix TDO timing and Fix command option processing error

### DIFF
--- a/xvcpi.c
+++ b/xvcpi.c
@@ -52,8 +52,8 @@ static uint32_t bcm2835gpio_xfer(int n, uint32_t tms, uint32_t tdi)
 
 	for (int i = 0; i < n; i++) {
 		bcm2835gpio_write(0, tms & 1, tdi & 1);
-		tdo |= bcm2835gpio_read() << i;
 		bcm2835gpio_write(1, tms & 1, tdi & 1);
+		tdo |= bcm2835gpio_read() << i;
 		tms >>= 1;
 		tdi >>= 1;
 	}

--- a/xvcpi.c
+++ b/xvcpi.c
@@ -262,17 +262,22 @@ int main(int argc, char **argv) {
       switch (c) {
       case 'v':
          verbose = 1;
+         break;
       case '?':
          fprintf(stderr, "usage: %s [-v] [-c 0~31] [-m 0~31] [-i 0~31] [-o 0~31]\n", *argv);
          return 1;
       case 'c':
          tck_gpio = atoi(optarg);
+         break;
       case 'm':
          tms_gpio = atoi(optarg);
+         break;
       case 'i':
          tdi_gpio = atoi(optarg);
+         break;
       case 'o':
          tdo_gpio = atoi(optarg);
+         break;
       }
 
    if (bcm2835gpio_init() < 1) {


### PR DESCRIPTION
1.  change GPIO order to sample TDO on the rising edge.
according to @nic3-14159's commit(https://github.com/derekmulcahy/xvcpi/commit/bf6e19c4c1dda23b21333371553c299cd47dcd1c) and JTAG Standard (IEEE Std 1149.1-2013), "Changes in the state of the signal driven through TDO shall occur only on the falling edge of either TCK or the optional TRST". Its better for the host to sample TDO jsut before the next falling edge of TCK.

2.  Add missing break statements in switch block to fix command option processing error.
